### PR TITLE
chore: update flutter dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -556,28 +556,28 @@ packages:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   path_provider_macos:
     dependency: transitive
     description:
       name: path_provider_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
   platform:
     dependency: transitive
     description:
@@ -757,7 +757,7 @@ packages:
       name: swagger_dart_code_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.2"
+    version: "2.3.4+1"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,11 +68,11 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^1.0.0
 
-  build_runner: any
-  json_serializable: any
+  build_runner: 2.1.7
+  json_serializable: 6.1.3
   test: '>=1.15.0 <2.0.0'
-  chopper_generator: any
-  swagger_dart_code_generator: any
+  chopper_generator: 4.0.3
+  swagger_dart_code_generator: 2.3.4+1
   nock: ^1.2.0
 
   # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/Mause/transit_dashboard/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>flutter pub upgrade --major-versions</em></summary>

```Shell
Resolving dependencies...
  _fe_analyzer_shared 31.0.0 (32.0.0 available)
  analyzer 2.8.0 (3.0.0 available)
  args 2.3.0
  async 2.8.2
  awesome_notifications 0.6.20
  boolean_selector 2.1.0
  build 2.2.1
  build_config 1.0.0
  build_daemon 3.0.1
  build_resolvers 2.0.6
  build_runner 2.1.7
  build_runner_core 7.2.3
  built_collection 5.1.1
  built_value 8.1.3
  characters 1.2.0
  charcode 1.3.1
  checked_yaml 2.0.1
  chopper 4.0.4
  chopper_generator 4.0.3
  cli_util 0.3.5
  clock 1.1.0
  code_builder 4.1.0
  collection 1.15.0
  convert 3.0.1
  coverage 1.0.3 (1.0.4 available)
  crypto 3.0.1
  cupertino_icons 1.0.4
  dart_style 2.2.1
  duration 3.0.8
  fake_async 1.2.0
  ffi 1.1.2
  file 6.1.2
  fixnum 1.0.0
  flutter 0.0.0 from sdk flutter
  flutter_lints 1.0.4
  flutter_test 0.0.0 from sdk flutter
  flutter_web_plugins 0.0.0 from sdk flutter
  frontend_server_client 2.1.2
  geolocator 8.0.1
  geolocator_android 3.0.1
  geolocator_apple 2.0.0+2
  geolocator_platform_interface 3.0.1
  geolocator_web 2.1.1
  get 4.6.1
  glob 2.0.2
  graphs 2.1.0
  hive 2.0.5
  hive_flutter 1.1.0
  http 0.13.4
  http_multi_server 3.0.1
  http_parser 4.0.0
  intl 0.17.0
  io 1.0.3
  js 0.6.3 (0.6.4 available)
  json_annotation 4.4.0
  json_serializable 6.1.3
  lints 1.0.1
  logger 1.1.0
  logging 1.0.2
  markdown 4.0.1
  matcher 0.12.11
  material_color_utilities 0.1.2 (0.1.3 available)
  material_you_colours 0.0.1 from git https://github.com/Mause/material_you_colours at 9bec0c
  meta 1.7.0
  mime 1.0.1
  nock 1.2.0
  node_preamble 2.0.1
  ordered_set 5.0.0
  package_config 2.0.2
  package_info_plus 1.3.0
  package_info_plus_linux 1.0.3
  package_info_plus_macos 1.3.0
  package_info_plus_platform_interface 1.0.2
  package_info_plus_web 1.0.4
  package_info_plus_windows 1.0.4
  path 1.8.0 (1.8.1 available)
  path_provider 2.0.8
  path_provider_android 2.0.11
  path_provider_ios 2.0.7
> path_provider_linux 2.1.5 (was 2.1.4)
> path_provider_macos 2.0.5 (was 2.0.4)
> path_provider_platform_interface 2.0.3 (was 2.0.2)
> path_provider_windows 2.0.5 (was 2.0.4)
  platform 3.1.0
  plugin_platform_interface 2.1.2
  pool 1.5.0
  process 4.2.4
  pub_semver 2.1.0
  pubspec_parse 1.2.0
  quiver 3.0.1+1
  recase 4.0.0
  sentry 6.2.2
  sentry_flutter 6.2.2
  sentry_logging 6.2.2
  shelf 1.2.0
  shelf_packages_handler 3.0.0
  shelf_static 1.1.0
  shelf_web_socket 1.0.1
  sky_engine 0.0.99 from sdk flutter
  source_gen 1.2.1
  source_helper 1.3.1
  source_map_stack_trace 2.1.0
  source_maps 0.10.10
  source_span 1.8.1
  stack_trace 1.10.0
  stream_channel 2.1.0
  stream_transform 2.0.0
  string_scanner 1.1.0
> swagger_dart_code_generator 2.3.4+1 (was 2.3.2)
  term_glyph 1.2.0
  test 1.19.5 (1.20.1 available)
  test_api 0.4.8 (0.4.9 available)
  test_core 0.4.9 (0.4.11 available)
  timezone 0.8.0
  timing 1.0.0
  tuple 2.0.0
  typed_data 1.3.0
  universal_io 2.0.4
  uuid 3.0.5
  vector_math 2.1.1
  vm_service 7.5.0 (8.1.0 available)
  watcher 1.0.1
  web_socket_channel 2.1.0
  webkit_inspection_protocol 1.0.0
  win32 2.3.3
  workmanager 0.4.1
  xdg_directories 0.2.0
  yaml 3.1.0
Downloading path_provider_windows 2.0.5...
Downloading path_provider_platform_interface 2.0.3...
Downloading path_provider_macos 2.0.5...
Downloading path_provider_linux 2.1.5...
Downloading swagger_dart_code_generator 2.3.4+1...
Changed 5 dependencies!
10 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.

No changes to pubspec.yaml!
```



</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- pubspec.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)