### PR TITLE
chore: update flutter dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -834,7 +834,7 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -267,7 +267,7 @@ packages:
       name: geolocator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.0.5"
+    version: "8.1.1"
   geolocator_android:
     dependency: transitive
     description:
@@ -288,7 +288,7 @@ packages:
       name: geolocator_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   geolocator_web:
     dependency: transitive
     description:
@@ -296,6 +296,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.4"
+  geolocator_windows:
+    dependency: transitive
+    description:
+      name: geolocator_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
   get:
     dependency: "direct main"
     description:
@@ -434,7 +441,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: a52ee848ae12aa985d4e80decd022f21c47d9e32
+      resolved-ref: f6940bb198096b5901c25d4206633102af8e3d5b
       url: "https://github.com/Mause/material_you_colours"
     source: git
     version: "0.0.1"
@@ -640,21 +647,21 @@ packages:
       name: sentry
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.2.2"
+    version: "6.3.0"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.2.2"
+    version: "6.3.0"
   sentry_logging:
     dependency: "direct main"
     description:
       name: sentry_logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.2.2"
+    version: "6.3.0"
   shelf:
     dependency: transitive
     description:
@@ -869,7 +876,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.10"
+    version: "2.3.11"
   workmanager:
     dependency: "direct main"
     description:
@@ -883,7 +890,7 @@ packages:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.0+1"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -351,7 +351,7 @@ packages:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.2.0"
   http_parser:
     dependency: transitive
     description:
@@ -542,7 +542,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.0.9"
   path_provider_android:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -379,7 +379,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   json_annotation:
     dependency: "direct main"
     description:
@@ -535,7 +535,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   path_provider:
     dependency: transitive
     description:
@@ -778,21 +778,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.19.5"
+    version: "1.20.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.11"
   timezone:
     dependency: "direct main"
     description:
@@ -899,5 +899,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.15.0 <3.0.0"
+  dart: ">=2.16.0-100.0.dev <3.0.0"
   flutter: ">=2.10.0-0.3.pre"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -493,7 +493,7 @@ packages:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   package_info_plus_linux:
     dependency: transitive
     description:
@@ -764,7 +764,7 @@ packages:
       name: swagger_dart_code_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.13"
+    version: "2.4.1"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -493,7 +493,7 @@ packages:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   package_info_plus_linux:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -549,7 +549,7 @@ packages:
       name: path_provider_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.8"
   path_provider_linux:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "34.0.0"
+    version: "36.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "3.3.1"
   args:
     dependency: transitive
     description:
@@ -134,13 +134,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.5"
-  cli_util:
-    dependency: transitive
-    description:
-      name: cli_util
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.3.5"
   clock:
     dependency: transitive
     description:
@@ -330,7 +323,7 @@ packages:
       name: hive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.6"
   hive_flutter:
     dependency: "direct main"
     description:
@@ -549,7 +542,7 @@ packages:
       name: path_provider_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.11"
+    version: "2.0.12"
   path_provider_ios:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -267,7 +267,7 @@ packages:
       name: geolocator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.1"
+    version: "8.2.0"
   geolocator_android:
     dependency: transitive
     description:
@@ -281,7 +281,7 @@ packages:
       name: geolocator_apple
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.1+1"
   geolocator_platform_interface:
     dependency: transitive
     description:
@@ -876,7 +876,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.11"
+    version: "2.4.0"
   workmanager:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -281,14 +281,14 @@ packages:
       name: geolocator_apple
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   geolocator_platform_interface:
     dependency: transitive
     description:
       name: geolocator_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.2"
+    version: "4.0.3"
   geolocator_web:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -441,10 +441,10 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: e8b07b5dca6f697f858c2ca792b8caaeb1a2bea6
+      resolved-ref: "0542eae93b035b0b8f790854dc2ba39fd791c489"
       url: "https://github.com/Mause/material_you_colours"
     source: git
-    version: "0.0.1"
+    version: "0.0.1-pre0"
   meta:
     dependency: transitive
     description:
@@ -848,7 +848,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.0"
+    version: "8.2.0"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -441,7 +441,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: f6940bb198096b5901c25d4206633102af8e3d5b
+      resolved-ref: e8b07b5dca6f697f858c2ca792b8caaeb1a2bea6
       url: "https://github.com/Mause/material_you_colours"
     source: git
     version: "0.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "31.0.0"
+    version: "34.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.0"
+    version: "3.2.0"
   args:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: chopper_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.3"
+    version: "4.0.5"
   cli_util:
     dependency: transitive
     description:
@@ -175,7 +175,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.1.0"
   crypto:
     dependency: transitive
     description:
@@ -848,7 +848,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.5.0"
+    version: "8.1.0"
   watcher:
     dependency: transitive
     description:
@@ -876,7 +876,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   workmanager:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -274,14 +274,14 @@ packages:
       name: geolocator_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.0"
   geolocator_apple:
     dependency: transitive
     description:
       name: geolocator_apple
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   geolocator_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -434,7 +434,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "0542eae93b035b0b8f790854dc2ba39fd791c489"
+      resolved-ref: "223290864ee19ceb4fb8f0c8081e3663eaac602e"
       url: "https://github.com/Mause/material_you_colours"
     source: git
     version: "0.0.1-pre0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -71,7 +71,7 @@ dev_dependencies:
   build_runner: 2.1.7
   json_serializable: ^6.1.4
   test: '>=1.15.0 <2.0.0'
-  chopper_generator: 4.0.3
+  chopper_generator: ^4.0.5
   swagger_dart_code_generator: ^2.3.8
   nock: ^1.2.0
 


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/Mause/transit_dashboard/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>flutter pub upgrade --major-versions</em></summary>

```Shell
Resolving dependencies...
  _fe_analyzer_shared 31.0.0 (34.0.0 available)
  analyzer 2.8.0 (3.2.0 available)
  args 2.3.0
  async 2.8.2
  awesome_notifications 0.6.21
  boolean_selector 2.1.0
  build 2.2.1
  build_config 1.0.0
  build_daemon 3.0.1
  build_resolvers 2.0.6
  build_runner 2.1.7
  build_runner_core 7.2.3
  built_collection 5.1.1
  built_value 8.1.4
  characters 1.2.0
  charcode 1.3.1
  checked_yaml 2.0.1
  chopper 4.0.5
  chopper_generator 4.0.3 (4.0.5 available)
  cli_util 0.3.5
  clock 1.1.0
  code_builder 4.1.0
  collection 1.15.0
  convert 3.0.1
  coverage 1.0.3 (1.1.0 available)
  crypto 3.0.1
  cupertino_icons 1.0.4
  dart_style 2.2.1
  duration 3.0.8
  fake_async 1.2.0
  ffi 1.1.2
  file 6.1.2
  fixnum 1.0.0
  flutter 0.0.0 from sdk flutter
  flutter_lints 1.0.4
  flutter_test 0.0.0 from sdk flutter
  flutter_web_plugins 0.0.0 from sdk flutter
  frontend_server_client 2.1.2
> geolocator 8.1.1 (was 8.0.5)
  geolocator_android 3.0.2 (3.0.3 available)
  geolocator_apple 2.0.1
> geolocator_platform_interface 4.0.2 (was 4.0.1)
  geolocator_web 2.1.4
+ geolocator_windows 0.1.0
  get 4.6.1
  glob 2.0.2
  graphs 2.1.0
  hive 2.0.5
  hive_flutter 1.1.0
  http 0.13.4
  http_multi_server 3.0.1
  http_parser 4.0.0
  intl 0.17.0
  io 1.0.3
  js 0.6.3 (0.6.4 available)
  json_annotation 4.4.0
  json_serializable 6.1.4
  lints 1.0.1
  logger 1.1.0
  logging 1.0.2
  markdown 4.0.1
  matcher 0.12.11
  material_color_utilities 0.1.3 (0.1.4 available)
* material_you_colours 0.0.1 from git https://github.com/Mause/material_you_colours at f6940b (was 0.0.1 from git https://github.com/Mause/material_you_colours at a52ee8)
  meta 1.7.0
  mime 1.0.1
  nock 1.2.0
  node_preamble 2.0.1
  ordered_set 5.0.0
  package_config 2.0.2
  package_info_plus 1.3.0
  package_info_plus_linux 1.0.3
  package_info_plus_macos 1.3.0
  package_info_plus_platform_interface 1.0.2
  package_info_plus_web 1.0.4
  package_info_plus_windows 1.0.4
  path 1.8.0 (1.8.1 available)
  path_provider 2.0.8
  path_provider_android 2.0.11
  path_provider_ios 2.0.7
  path_provider_linux 2.1.5
  path_provider_macos 2.0.5
  path_provider_platform_interface 2.0.3
  path_provider_windows 2.0.5
  platform 3.1.0
  plugin_platform_interface 2.1.2
  pool 1.5.0
  process 4.2.4
  pub_semver 2.1.0
  pubspec_parse 1.2.0
  quiver 3.0.1+1
  recase 4.0.0
> sentry 6.3.0 (was 6.2.2)
> sentry_flutter 6.3.0 (was 6.2.2)
> sentry_logging 6.3.0 (was 6.2.2)
  shelf 1.2.0
  shelf_packages_handler 3.0.0
  shelf_static 1.1.0
  shelf_web_socket 1.0.1
  sky_engine 0.0.99 from sdk flutter
  source_gen 1.2.1
  source_helper 1.3.1
  source_map_stack_trace 2.1.0
  source_maps 0.10.10
  source_span 1.8.1 (1.8.2 available)
  stack_trace 1.10.0
  stream_channel 2.1.0
  stream_transform 2.0.0
  string_scanner 1.1.0
  swagger_dart_code_generator 2.3.13
  term_glyph 1.2.0
  test 1.19.5 (1.20.1 available)
  test_api 0.4.8 (0.4.9 available)
  test_core 0.4.9 (0.4.11 available)
  timezone 0.8.0
  timing 1.0.0
  tuple 2.0.0
  typed_data 1.3.0
  universal_io 2.0.4
  uuid 3.0.5
  vector_math 2.1.1 (2.1.2 available)
  vm_service 7.5.0 (8.1.0 available)
  watcher 1.0.1
  web_socket_channel 2.1.0
  webkit_inspection_protocol 1.0.0
> win32 2.3.11 (was 2.3.10)
  workmanager 0.4.1
> xdg_directories 0.2.0+1 (was 0.2.0)
  yaml 3.1.0
Downloading geolocator 8.1.1...
Downloading geolocator_windows 0.1.0...
Downloading geolocator_platform_interface 4.0.2...
Downloading sentry_logging 6.3.0...
Downloading sentry 6.3.0...
Downloading sentry_flutter 6.3.0...
Downloading xdg_directories 0.2.0+1...
Downloading win32 2.3.11...
Changed 9 dependencies!
14 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.

No changes to pubspec.yaml!
```



</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- pubspec.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)